### PR TITLE
Fix: ライブラリ不足のため yum install が失敗する

### DIFF
--- a/04chapter/Dockerfile
+++ b/04chapter/Dockerfile
@@ -26,6 +26,9 @@ RUN yum install -y zip \
                    git \
                    systemd-sysv \
                    libxslt \
+                   openssl-devel \
+                   libxml2-devel \
+                   libedit-devel \
                    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
                    http://rpms.famillecollet.com/enterprise/remi-release-7.rpm
 


### PR DESCRIPTION
2020年8月1日に `docker build -t mixserver .` を実行したところ、失敗したので修正いたしました。